### PR TITLE
Add Hygrometer trait

### DIFF
--- a/i2csensors/Cargo.toml
+++ b/i2csensors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "i2csensors"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["martindeegan <mddeegan@gmail.com>"]
 description = "Traits for I2C sensors."
 repository = "https://github.com/martindeegan/i2cdev-sensors"

--- a/i2csensors/src/lib.rs
+++ b/i2csensors/src/lib.rs
@@ -137,5 +137,10 @@ impl<T> Altimeter for T
     }
 }
 
+/// Trait for sensors that provide access to humidity readings
+pub trait Hygrometer {
+    type Error: Error;
 
-
+    /// Read the relative humidity from the sensor in percent
+    fn relative_humidity(&mut self) -> Result<f32, Self::Error>;
+}


### PR DESCRIPTION
The `Hygrometer` trait allows reading the relative humidity.

It would be nice if you could release a new version once this is merged (I included a commit that bumps the version).

I need this for a driver for the [Si7021](https://www.silabs.com/documents/public/data-sheets/Si7021-A20.pdf). I am a little confused about the situation regarding the project structure. Should I add a PR with the driver against your repository, against Kixunil's or just publish the driver myself?