### PR TITLE
[WIP] i2csensors: Become no_std

### DIFF
--- a/i2csensors/src/lib.rs
+++ b/i2csensors/src/lib.rs
@@ -5,9 +5,9 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
 // option.  This file may not be copied, modified, or distributed
 // except according to those terms.
+#![no_std]
 
-use std::error::Error;
-use std::ops::{Add, Sub, Mul, Div};
+use core::ops::{Add, Sub, Mul, Div};
 
 #[derive(Debug, Copy, Clone)]
 pub struct Vec3 {
@@ -72,21 +72,21 @@ impl Div<f32> for Vec3 {
 
 /// Trait for sensors that provide access to accelerometer readings (3-axis)
 pub trait Accelerometer {
-    type Error: Error;
+    type Error;
 
     /// Returns 'Ok(accel)' if available, otherwise returns 'Err(Self::Error)'
     fn acceleration_reading(&mut self) -> Result<Vec3, Self::Error>;
 }
 
 pub trait Gyroscope {
-    type Error: Error;
+    type Error;
 
     /// Returns 'Ok(ang_rate)' if available, otherwise returns 'Err(Self::Error)'
     fn angular_rate_reading(&mut self) -> Result<Vec3, Self::Error>;
 }
 
 pub trait Magnetometer {
-    type Error: Error;
+    type Error;
 
     /// Returns 'Ok(mag)' if available, otherwise returns 'Err(Self::Error)'
     fn magnetic_reading(&mut self) -> Result<Vec3, Self::Error>;
@@ -94,7 +94,7 @@ pub trait Magnetometer {
 
 /// Trait for sensors that provide access to temperature readings
 pub trait Thermometer {
-    type Error: Error;
+    type Error;
 
     /// Get a temperature from the sensor in degrees celsius
     ///
@@ -104,7 +104,7 @@ pub trait Thermometer {
 
 /// Trait for sensors that provide access to pressure readings
 pub trait Barometer {
-    type Error: Error;
+    type Error;
 
     /// Get a pressure reading from the sensor in kPa
     ///
@@ -114,7 +114,7 @@ pub trait Barometer {
 
 /// Trait for sensors that provide access to altitude readings
 pub trait Altimeter {
-    type Error: Error;
+    type Error;
 
     /// Get an altitude reading from the sensor in meters, relative to the pressure in kPa at
     /// sea level
@@ -123,23 +123,23 @@ pub trait Altimeter {
     fn altitude_meters(&mut self, sea_level_kpa: f32) -> Result<f32, Self::Error>;
 }
 
-impl<T> Altimeter for T
-    where T: Barometer
-{
-    type Error = <Self as Barometer>::Error;
-
-    fn altitude_meters(&mut self, sea_level_kpa: f32) -> Result<f32, Self::Error> {
-        let pressure = try!(self.pressure_kpa()) * 1000.;
-        let sea_level_pa = sea_level_kpa * 1000.;
-
-        let altitude = 44330. * (1. - (pressure / sea_level_pa).powf(0.1903));
-        Ok(altitude)
-    }
-}
+// impl<T> Altimeter for T
+//     where T: Barometer
+// {
+//     type Error = <Self as Barometer>::Error;
+//
+//     fn altitude_meters(&mut self, sea_level_kpa: f32) -> Result<f32, Self::Error> {
+//         let pressure = try!(self.pressure_kpa()) * 1000.;
+//         let sea_level_pa = sea_level_kpa * 1000.;
+//
+//         let altitude = 44330. * (1. - (pressure / sea_level_pa).powf(0.1903));
+//         Ok(altitude)
+//     }
+// }
 
 /// Trait for sensors that provide access to humidity readings
 pub trait Hygrometer {
-    type Error: Error;
+    type Error;
 
     /// Read the relative humidity from the sensor in percent
     fn relative_humidity(&mut self) -> Result<f32, Self::Error>;


### PR DESCRIPTION
* Numeric traits are replaced with their core counterparts.
* Errors don't need to implement std:error::Error any more.
* Altitude-from-pressure was commented out until there is a libm
  implementation of powf ([1], probably)

[1]: https://github.com/rust-num/num-traits/issues/75

---

This is early work to allow using the I2C sensor traits also on no_std platforms, like in https://github.com/klemens/si7021-rs/issues/1. Before I proceed here, I'd like to solicit the maintainer's opinions:

* Are the type constraints on T::Error to be std::Error actually justified and depended on? (My impression is that as long as one uses base devices whose errors are std, they're usable in the end anyway; only "sensor middleware" like Altimeter for Barometer can't access the error types as std if they're not required, and they can still restrict their implementations to `where T::Error: std::error::Error` if they do need that.)
* If they need to stay, would you be OK with a configure feature that waives that limitation?