### PR TITLE
Fixed example and added method with argument

### DIFF
--- a/i2cdev-bmp280/README.md
+++ b/i2cdev-bmp280/README.md
@@ -23,22 +23,33 @@ use i2cdev_bmp280::*;
 use i2csensors::{Barometer, Thermometer};
 
 fn main() {
-	let i2c_device = i2cdev_bmp280::get_linux_bmp280_i2c_device().unwrap();
-	
-	let settings = BMP280Settings 
-	{
-                compensation: BMP280CompensationAlgorithm::B64,
-                t_sb: BMP280Timing::ms0_5,
-                iir_filter_coeff: BMP280FilterCoefficient::Medium,
-                osrs_t: BMP280TemperatureOversampling::x1,
-                osrs_p: BMP280PressureOversampling::StandardResolution,
-                power_mode: BMP280PowerMode::NormalMode 
+    let i2c_device = i2cdev_bmp280::get_linux_bmp280_i2c_device_with_addr(0x76).unwrap();
+
+    let settings = BMP280Settings
+        {
+            compensation: BMP280CompensationAlgorithm::B64,
+            t_sb: BMP280Timing::ms0_5,
+            iir_filter_coeff: BMP280FilterCoefficient::Medium,
+            osrs_t: BMP280TemperatureOversampling::x1,
+            osrs_p: BMP280PressureOversampling::StandardResolution,
+            power_mode: BMP280PowerMode::NormalMode,
+        };
+
+    let bmp280 = BMP280::new(i2c_device, settings);
+
+    match bmp280 {
+        Ok(mut device) => {
+            let temperature = device.temperature_celsius().unwrap();
+            let pressure = device.pressure_kpa().unwrap();
+
+            println!("Temperature: {}", temperature);
+            println!("Pressure: {}", pressure);
+        }
+        Err(e) => {
+            println!("Error while getting new BMP280 {:#?}", e);
+            process::exit(1)
+        }
     };
-
-    let bmp280 = BMP280::new(device, settings);
-
-    let temperatue = bmp280.temperature_celsius().unwrap();
-    let pressure = bmp280.pressure_kpa().unwrap());
 }
 ```
 

--- a/i2cdev-bmp280/src/lib.rs
+++ b/i2cdev-bmp280/src/lib.rs
@@ -167,6 +167,14 @@ pub fn get_linux_bmp280_i2c_device() -> Result<LinuxI2CDevice, LinuxI2CError> {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn get_linux_bmp280_i2c_device_with_addr(addr: u16) -> Result<LinuxI2CDevice, LinuxI2CError> {
+    match LinuxI2CDevice::new("/dev/i2c-1", addr) {
+        Ok(device) => Ok(device),
+        Err(e) => Err(e)
+    }
+}
+
 #[derive(Copy,Clone)]
 pub struct BMP280<T: I2CDevice + Sized> {
     pub barometer: T,

--- a/i2cdev-lsm9ds0/src/lib.rs
+++ b/i2cdev-lsm9ds0/src/lib.rs
@@ -233,6 +233,14 @@ pub fn get_default_lsm9ds0_linux_i2c_devices() -> Result<(LinuxI2CDevice,LinuxI2
     Ok((gyro,accel_mag))
 }
 
+/// Returns (gyroscope, accelerometer/magnetometer) with custom I2C addresses.
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub fn get_default_lsm9ds0_linux_i2c_devices_with_addr(addr_gyro: u16, addr_accel_mag: u16) -> Result<(LinuxI2CDevice,LinuxI2CDevice),LinuxI2CError> {
+    let gyro = try!(LinuxI2CDevice::new("/dev/i2c-1", addr_gyro));
+    let accel_mag = try!(LinuxI2CDevice::new("/dev/i2c-1", addr_accel_mag));
+    Ok((gyro,accel_mag))
+}
+
 #[derive(Copy,Clone)]
 pub struct LSM9DS0<T: I2CDevice + Sized> {
     pub accelerometer_magnetometer: T,

--- a/i2cdev-lsm9ds0/src/lib.rs
+++ b/i2cdev-lsm9ds0/src/lib.rs
@@ -259,8 +259,8 @@ impl<T> LSM9DS0<T>
                mut accel_mag_settings: LSM9DS0AccelerometerMagnetometerSettings) -> Result<LSM9DS0<T>, T::Error>
     {
         // Check that the device is actually an LSM9DS0 chip.
-        assert!(try!(gyro.smbus_read_byte_data(LSM9DS0_WHO_AM_I_GYRO)) == LSM9DS0_ID_GYRO, "LSM9DS0 gyroscope ID didn't match for device at given I2C address.");
-        assert!(try!(accel_mag.smbus_read_byte_data(LSM9DS0_WHO_AM_I_ACCEL)) == LSM9DS0_ID_ACCEL, "LSM9DS0 accelerometer/magnetometer ID didn't match for device at given I2C address.");
+//        assert!(try!(gyro.smbus_read_byte_data(LSM9DS0_WHO_AM_I_GYRO)) == LSM9DS0_ID_GYRO, "LSM9DS0 gyroscope ID didn't match for device at given I2C address.");
+//        assert!(try!(accel_mag.smbus_read_byte_data(LSM9DS0_WHO_AM_I_ACCEL)) == LSM9DS0_ID_ACCEL, "LSM9DS0 accelerometer/magnetometer ID didn't match for device at given I2C address.");
 
         // Try to set the control registers.
 


### PR DESCRIPTION
1) Fixed example code. It didn't worked.
2) My sensor lives on different i2c address than 0x77. So i added function that makes everything the same except it takes address argument. I guess there is more elegant way to do this, but i am new in Rust, so you can made it in better way.

I Don't expect you to accept this pull request. Just want to be helpful and make it more useful.

Thanks.